### PR TITLE
NNBD git dependency / workaround for current beta channel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+## Important
+
+Working fork for flutter beta channel (with null safety braking changes). 
+
+Probably obsolote after 3. March 2021
+
+This branch can be used per direct git dependency:
+
+```yml
+  device_preview:
+    git:
+      url: https://github.com/FluentChange/flutter_device_preview.git
+      path: device_preview
+      ref: nnbd_git_dependency
+```
+
 <p align="center">
   <img src="https://github.com/aloisdeniel/flutter_device_preview/raw/master/logo.png" alt="Device Preview for Flutter" />
 </p>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Working fork for flutter beta channel (with null safety breaking changes). 
 
-Probably obsolote after 3. March 2021
+Probably obsolete after 3. March 2021
 
 This branch can be used per direct git dependency:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Important
 
-Working fork for flutter beta channel (with null safety braking changes). 
+Working fork for flutter beta channel (with null safety breaking changes). 
 
 Probably obsolote after 3. March 2021
 

--- a/device_preview/pubspec.yaml
+++ b/device_preview/pubspec.yaml
@@ -1,6 +1,7 @@
 name: device_preview
 version: 0.7.0-nullsafety.0
 description: Approximate how your Flutter app looks and performs on another device.
+publish_to: "none"
 homepage: https://github.com/aloisdeniel/flutter_device_preview
 
 environment:
@@ -13,7 +14,8 @@ dependencies:
     sdk: flutter
   provider: ^5.0.0-nullsafety.3
   path_provider: ^2.0.0-nullsafety
-  device_frame: ^0.4.0-nullsafety.0
+  device_frame:
+    path: ../device_frame
   font_awesome_flutter: ^9.0.0-nullsafety
   http: ^0.13.0-nullsafety.0
   freezed_annotation: ">=0.13.0-nullsafety.0 <1.0.0"


### PR DESCRIPTION
Hello Jesse,

thanks for your awesome fixes.
Here some little changes to have temporary usable solution.

Your nnbd branch has invalid/not yet existing dependency
`device_frame: ^0.4.0-nullsafety.0`

So i suggest not to merge this PR into your nnbd, better pull the branch into a new one.
P.S. I will also suggest my fork+branch to Alois

Best regards,
Frank